### PR TITLE
Updates controller image tag to v0.2.3

### DIFF
--- a/charts/dynamic-pvc-provisioner/Chart.yaml
+++ b/charts/dynamic-pvc-provisioner/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.0"
+appVersion: "0.2.3"

--- a/charts/reclaimable-pv-releaser/Chart.yaml
+++ b/charts/reclaimable-pv-releaser/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.0"
+appVersion: "0.2.3"


### PR DESCRIPTION
Closes #1 
Currently, the helm chart uses the v0.2.0 version of the controller, which leads to some issues when the number of PV to track is significant (faced issues with ~1000 PV), due to which the Releaser was not changing the PV state to Available. 

Updating the controller version to v0.2.3 resolved the problem, as it skipped the re-queuing of objects.